### PR TITLE
added in bonds to molecule class; added impropers

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,7 +19,7 @@ run the following from the top level of the  hoomdxml_reader directory.
     $ conda env create -f environment.yml
 
 Optional packages
-----------------
+-----------------
 While not necessary to use the core functions of the Module, conversion to an mBuild ``Compound``, requires `mbuild <https://mbuild.mosdef.org/en/stable/getting_started/installation/installation.html>`_ to be installed.
 
     $ conda install -c conda-forge mbuild
@@ -168,6 +168,7 @@ Other calls that correspond to each section in the XML data file shown above:
     system.bonds
     system.angles
     system.dihedrals
+    system.impropers
     system.masses
     system.charges
     system.bond_order
@@ -188,7 +189,7 @@ The following code prints information related to each molecule.
 .. code:: ipython3
 
     for molecule in system.molecules:
-        print(molecule.name, molecule.particles, molecule.types, molecule.pattern)
+        print(molecule.name, molecule.particles, molecule.types, molecule.pattern, molecule.bonds)
  
  
 *output*:
@@ -286,7 +287,7 @@ If py3Dmol is installed in your environment the mb_system can be easily visualiz
 .. code:: ipython3
 
         mb_system.visualize()
-        
+  
 The following code snippets demonstrate how to access information within the mBuild ``Compound`` that we created. Again, the goal was to define the ``Compound`` in such a way that it mimics the hierarchy in the ``System`` class. To access individual molecules, we can use the following syntax show below; this is possible because each molecule that was added to the mBuild ``Compound`` was given a label with the following syntax 'molecule[$]'. E.g., to access the first and third molecules in the system:
 
 
@@ -368,3 +369,18 @@ Similar to molecules, particles in each molecule are added with the labels ``par
 
 .. note::
     mBuild Compounds will contain information about position, particle type (i.e. name), molecule name, mass, charge, and any bonds.  Angle and dihedral information is not included, nor are quantities calculated automatically in the System class, such as bond order.
+
+We can additionally restrict the conversion to specific unique molecules by passing a list of molecule names via the name_selection variable. For example, we can restrict our conversion to only the water molecules in the system:
+
+.. code:: ipython3
+
+    mb_system = convert.System_to_Compound(system, name_selection=['water'])
+
+An individual molecule in the System class can be converted to an mBuild Compound.  This function can be used if one desires to have increased customization of the conversion than is provided in the System_to_Compound function.
+
+.. code:: ipython3
+
+    mb_molecule = convert.Molecule_to_Compound(system, system.molecules[0],
+                                                name=system.molecules[0].name)
+                                                
+                                                

--- a/hoomdxml_reader/hoomdxml_reader.py
+++ b/hoomdxml_reader/hoomdxml_reader.py
@@ -61,6 +61,10 @@ class System(object):
         List of all dihedrals in the system.  The first entry per dihedral is the
         name of the dihedral (str) as defined in the xml file,
         followed by indices for each particle in the dihedral.
+    impropers : list, shape=(5, n_particles), dtype=(str, int, int, int, int)
+        List of all impropers in the system.  The first entry per improper is the
+        name of the improper (str) as defined in the xml file,
+        followed by indices for each particle in the impropers.
     molecules : list, dtype=Molecule
         List containing each molecule identified by the code. Each entry
         in the list is an instance of the Molecule class.
@@ -173,7 +177,8 @@ class System(object):
         self._bonds = self._parse_topology(element='bond', length=3)
         self._angles = self._parse_topology(element='angle', length=4)
         self._dihedrals = self._parse_topology(element='dihedral', length=5)
-    
+        self._impropers = self._parse_topology(element='improper', length=5)
+
         # calculate bond_order
         for i in range(0, self.n_particles):
             self._bond_order.append(0)
@@ -197,7 +202,9 @@ class System(object):
             
             for item in temp:
                 mol_temp.add_particle(item, self._types[item])
-                
+            for edge in self._graph.subgraph(c).edges:
+                mol_temp.add_bond(list(edge))
+            
             self._molecules.append(mol_temp)
             
         if self._ignore_zero_bond_order == False:
@@ -263,7 +270,12 @@ class System(object):
     def dihedrals(self):
         """A list of all dihedrals defined in the source file"""
         return self._dihedrals
-        
+
+    @property
+    def impropers(self):
+        """A list of all dihedrals defined in the source file"""
+        return self._impropers
+
     @property
     def molecules(self):
         """This is a list of all molecules found in the system, where each entry corresponds to an instance of the Molecule class."""

--- a/hoomdxml_reader/molecule.py
+++ b/hoomdxml_reader/molecule.py
@@ -34,6 +34,7 @@ class Molecule(object):
     def __init__(self):
         self._particles = []
         self._types = []
+        self._bonds = []
         self._pattern = ''
         self._name = 'none'
     
@@ -44,16 +45,24 @@ class Molecule(object):
         
     def set_molecule_name(self, molecule_name):
         self._name = molecule_name
+        
+    def add_bond(self, bond):
+        self._bonds.append(bond)
 
     @property
     def particles(self):
-        """A list of indices correspoding to the particles in the molecule. These are listed in numerical order from lowest to highest."""
+        """A list of indices correspoding to the particles in the molecule. These are listed in numerical order from lowest to highest. These correspond to the numbers assigned in the system class."""
         return self._particles
         
     @property
     def types(self):
         """A list containing the type of the particle stores in the particles list, listed in the same order."""
         return self._types
+
+    @property
+    def bonds(self):
+        """A list containing the bonds in the molecule. Integer particle ids refer to numbers in the entire system."""
+        return self._bonds
 
     @property
     def pattern(self):

--- a/hoomdxml_reader/tests/example.hoomdxml
+++ b/hoomdxml_reader/tests/example.hoomdxml
@@ -64,5 +64,9 @@
             CH3-CH2-CH2-CH2 0 1 2 3
             CH2-CH2-CH2-CH3 1 2 3 4
         </dihedral>
+        <improper>
+            CH3-CH2-CH2-CH2 0 1 2 3
+            CH2-CH2-CH2-CH3 1 2 3 4
+        </improper>
     </configuration>
 </hoomd_xml>

--- a/hoomdxml_reader/tests/test_hoomdxml_reader.py
+++ b/hoomdxml_reader/tests/test_hoomdxml_reader.py
@@ -47,7 +47,10 @@ def test_loader():
     
     assert len(system.dihedrals) == 2
     assert system.dihedrals == [['CH3-CH2-CH2-CH2', 0, 1, 2, 3], ['CH2-CH2-CH2-CH3', 1, 2, 3, 4]]
-    
+ 
+    assert len(system.impropers) == 2
+    assert system.impropers == [['CH3-CH2-CH2-CH2', 0, 1, 2, 3], ['CH2-CH2-CH2-CH3', 1, 2, 3, 4]]
+
     assert len(system.masses) == 10
     assert system.masses == [15.0, 14.0, 14.0, 14.0, 15.0, 18.0, 18.0, 18.0, 18.0, 18.0]
 
@@ -148,6 +151,8 @@ def test_mBuild_conversion():
     
     mb_system = convert.System_to_Compound(system)
     
+    assert mb_system.n_particles == 10
+
     assert len(mb_system['molecule']) == 6
     assert len(mb_system['molecule'][0]['particle']) == 5
     assert len(mb_system['molecule'][1]['particle']) == 1
@@ -203,3 +208,40 @@ def test_mBuild_conversion():
     assert list(mb_system['molecule'][3]['particle'][0].pos) == [3.0, 1.0, 3.0]
     assert list(mb_system['molecule'][4]['particle'][0].pos) == [2.5, 0.0, 1.0]
     assert list(mb_system['molecule'][5]['particle'][0].pos) == [0.0, 2.0, 4.0]
+
+    mb_system_pentane = convert.System_to_Compound(system, name_selection=['pentane'])
+    assert mb_system_pentane.n_particles == 5
+    assert mb_system_pentane['molecule'][0].name == 'pentane'
+    
+    assert list(mb_system_pentane['molecule'][0]['particle'][0].pos) == [0.0, 0.0, 0.0]
+    assert list(mb_system_pentane['molecule'][0]['particle'][1].pos) == [0.5, 0.0, 0.0]
+    assert list(mb_system_pentane['molecule'][0]['particle'][2].pos) == [1.0, 0.0, 0.0]
+    assert list(mb_system_pentane['molecule'][0]['particle'][3].pos) == [1.5, 0.0, 0.0]
+    assert list(mb_system_pentane['molecule'][0]['particle'][4].pos) == [2.0, 0.0, 0.0]
+    
+    assert mb_system_pentane['molecule'][0]['particle'][0].n_direct_bonds == 1
+    assert mb_system_pentane['molecule'][0]['particle'][1].n_direct_bonds == 2
+    assert mb_system_pentane['molecule'][0]['particle'][2].n_direct_bonds == 2
+    assert mb_system_pentane['molecule'][0]['particle'][3].n_direct_bonds == 2
+    assert mb_system_pentane['molecule'][0]['particle'][4].n_direct_bonds == 1
+    
+    
+    mb_system_sol = convert.System_to_Compound(system, name_selection=['SOL'])
+    assert mb_system_sol.n_particles == 5
+    assert mb_system_sol['molecule'][0].name == 'SOL'
+    assert mb_system_sol['molecule'][1].name == 'SOL'
+    assert mb_system_sol['molecule'][2].name == 'SOL'
+    assert mb_system_sol['molecule'][3].name == 'SOL'
+    assert mb_system_sol['molecule'][4].name == 'SOL'
+
+    assert list(mb_system_sol['molecule'][0]['particle'][0].pos) == [0.0, 1.0, 0.0]
+    assert list(mb_system_sol['molecule'][1]['particle'][0].pos) == [0.5, 0.5, 2.0]
+    assert list(mb_system_sol['molecule'][2]['particle'][0].pos) == [3.0, 1.0, 3.0]
+    assert list(mb_system_sol['molecule'][3]['particle'][0].pos) == [2.5, 0.0, 1.0]
+    assert list(mb_system_sol['molecule'][4]['particle'][0].pos) == [0.0, 2.0, 4.0]
+
+    assert mb_system_sol['molecule'][0]['particle'][0].n_direct_bonds == 0
+    assert mb_system_sol['molecule'][1]['particle'][0].n_direct_bonds == 0
+    assert mb_system_sol['molecule'][2]['particle'][0].n_direct_bonds == 0
+    assert mb_system_sol['molecule'][3]['particle'][0].n_direct_bonds == 0
+    assert mb_system_sol['molecule'][4]['particle'][0].n_direct_bonds == 0


### PR DESCRIPTION
## Description
Molecule class was updated to included a list of the bonds in the molecule.  This was done to make it easier to convert an individual molecule to an mbuild compound.  

Additionally, support for impropers was added; I had neglected this earlier.
